### PR TITLE
Update location-info.pug

### DIFF
--- a/app_server/views/location-info.pug
+++ b/app_server/views/location-info.pug
@@ -39,7 +39,7 @@ block content
           .card.card-primary
             .card-block
               h2.card-title Location map
-              img.img-fluid.rounded(src='http://maps.googleapis.com/maps/api/staticmap?center=51.455041,-0.9690884&zoom=17&size=400x350&sensor=false&markers=51.455041,-0.9690884&scale=2')
+              img.img-fluid.rounded(src='http://maps.googleapis.com/maps/api/staticmap?center=51.455041,-0.9690884&zoom=17&size=400x350&sensor=false&markers=51.455041,-0.9690884&scale=2&key=ENTER-YOUR-Google-MAPS-API-KEY-HERE')
       .row
         .col-12
           .card.card-primary.review-card


### PR DESCRIPTION
The google maps static image no longer works without a free API Key. Updating the maps reference accordingly.